### PR TITLE
ArcpyMockup allows users without arcpy load arcapi

### DIFF
--- a/ArcpyMockup.py
+++ b/ArcpyMockup.py
@@ -1,0 +1,56 @@
+"""
+#-------------------------------------------------------------------------------
+# Name:        arcapi.ArcpyMockup
+# Purpose:     Class to pretend that arcpy is always present.
+#
+# Authors:     Filip Kral,
+#
+# Created:     28/07/2014
+# Licence:     LGPL v3
+#-------------------------------------------------------------------------------
+#
+# Not all functions in arcapi require arcpy. This module allows you to use
+# arcapi even if you don't have arcpy. The functions that require arcpy will
+# not work, but you can still use functions that do not need arcpy.
+# 
+#
+# You do not have to do anything to load arcapi, it has been coded to use this 
+# module. If you want to pretend that arcpy is present on computers without 
+# ArcGIS in your own projects, you can reuse the class from this module like so:
+#
+# try:
+#     import arcpy
+# except ImportError:
+#     arcpy = ArcpyMockup()
+#
+#-------------------------------------------------------------------------------
+"""
+
+from types import ModuleType
+
+class ArcpyMockup(ModuleType):
+    """This class will create object that looks like
+    the arcpy module on computers where arcpy is not
+    available so that users without arcpy can still use
+    arcapi functions that do not require arcpy.
+    Calls to functions that require arcpy will print
+    a WARNING message.
+    """
+    
+    def __init__(self):
+        """Create mockup of the arcpy module"""
+        self.da = None
+    
+    # override some methods
+    def AddMessage(self, m):
+        print m
+
+    def AddWarning(self, m):
+        print m
+
+    def __getattr__(self, key):
+        m = 'WARNING: Arcapi loaded without arcpy, %s not available' % key
+        print m
+        return None
+    
+    __all__ = []   # support wildcard imports

--- a/arcapi.py
+++ b/arcapi.py
@@ -19,10 +19,15 @@
 import os
 import sys
 import time
-import arcpy
+
+try:
+    import arcpy
+except ImportError:
+    from ArcpyMockup import ArcpyMockup
+    arcpy = ArcpyMockup()
 
 
-__version__ = '0.2.4'
+__version__ = '0.2.6'
 """Version number of arcapi"""
 
 
@@ -2534,21 +2539,26 @@ class ArcapiError(Exception):
 """
 Aliases
 =======
+Modified to allow computers without arcpy import arcapi.
+That is why instead of just:
+search = arcpy.da.SearchCursor
+we need:
+searcher = getattr(getattr(arcpy, "da", None), "SearchCursor", None)
 """
-searcher = arcpy.da.SearchCursor
-updater = arcpy.da.UpdateCursor
-inserter = arcpy.da.InsertCursor
-add_col = arcpy.management.AddField
-descr = arcpy.Describe
-flyr = arcpy.management.MakeFeatureLayer
-rlyr = arcpy.management.MakeRasterLayer
-tviw = arcpy.management.MakeTableView
+searcher = getattr(getattr(arcpy, "da", None), "SearchCursor", None)
+updater = getattr(getattr(arcpy, "da", None), "UpdateCursor", None)
+inserter = getattr(getattr(arcpy, "da", None), "InsertCursor", None)
+add_col = getattr(getattr(arcpy, "management", None), "AddField", None)
+descr = getattr(arcpy, "Describe", None)
+flyr = getattr(getattr(arcpy, "management", None), "MakeFeatureLayer", None)
+rlyr = getattr(getattr(arcpy, "management", None), "MakeRasterLayer", None)
+tviw = getattr(getattr(arcpy, "management", None), "MakeTableView", None)
 tos = to_scratch
 wsps = swsp
 osj = os.path.join
 bname = os.path.basename
 dname = os.path.dirname
-srs = arcpy.SpatialReference
+srs = getattr(arcpy, "SpatialReference", None)
 
 
 lut_field_types = {


### PR DESCRIPTION
The ArcpyMockup instance with pretend that arcpy is present on computers
where arcpy is not available. Therefore, you can load arcapi even if you
don't have arcpy and use some of its functions that do not require
arcpy.
